### PR TITLE
Roll back hair restrictions

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
@@ -2,7 +2,7 @@
   id: HumanHairAfro
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: afro
@@ -10,7 +10,7 @@
   id: HumanHairAfro2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: afro2
@@ -18,7 +18,7 @@
   id: HumanHairBigafro
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bigafro
@@ -26,7 +26,7 @@
   id: HumanHairAntenna
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: antenna
@@ -34,7 +34,7 @@
   id: HumanHairBalding
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: e
@@ -42,7 +42,7 @@
   id: HumanHairBedhead
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bedhead
@@ -50,7 +50,7 @@
   id: HumanHairBedheadv2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bedheadv2
@@ -58,7 +58,7 @@
   id: HumanHairBedheadv3
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bedheadv3
@@ -66,7 +66,7 @@
   id: HumanHairLongBedhead
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long_bedhead
@@ -74,7 +74,7 @@
   id: HumanHairFloorlengthBedhead
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: floorlength_bedhead
@@ -82,7 +82,7 @@
   id: HumanHairBeehive
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: beehive
@@ -90,7 +90,7 @@
   id: HumanHairBeehivev2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: beehivev2
@@ -98,7 +98,7 @@
   id: HumanHairBob
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bob
@@ -106,7 +106,7 @@
   id: HumanHairBob2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bob2
@@ -114,7 +114,7 @@
   id: HumanHairBobcut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bobcut
@@ -122,7 +122,7 @@
   id: HumanHairBob4
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bob4
@@ -130,7 +130,7 @@
   id: HumanHairBobcurl
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bobcurl
@@ -138,7 +138,7 @@
   id: HumanHairBoddicker
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: boddicker
@@ -146,7 +146,7 @@
   id: HumanHairBowlcut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bowlcut
@@ -154,7 +154,7 @@
   id: HumanHairBowlcut2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bowlcut2
@@ -162,7 +162,7 @@
   id: HumanHairBraid
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braid
@@ -170,7 +170,7 @@
   id: HumanHairBraided
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braided
@@ -178,7 +178,7 @@
   id: HumanHairBraidfront
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braidfront
@@ -186,7 +186,7 @@
   id: HumanHairBraid2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braid2
@@ -194,7 +194,7 @@
   id: HumanHairHbraid
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: hbraid
@@ -202,7 +202,7 @@
   id: HumanHairShortbraid
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shortbraid
@@ -210,7 +210,7 @@
   id: HumanHairBraidtail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braidtail
@@ -218,7 +218,7 @@
   id: HumanHairBun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bun
@@ -226,7 +226,7 @@
   id: HumanHairBunhead2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bunhead2
@@ -234,7 +234,7 @@
   id: HumanHairBun3
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bun3
@@ -242,7 +242,7 @@
   id: HumanHairLargebun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: largebun
@@ -250,7 +250,7 @@
   id: HumanHairManbun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: manbun
@@ -258,7 +258,7 @@
   id: HumanHairTightbun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: tightbun
@@ -266,7 +266,7 @@
   id: HumanHairBusiness
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business
@@ -274,7 +274,7 @@
   id: HumanHairBusiness2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business2
@@ -282,7 +282,7 @@
   id: HumanHairBusiness3
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business3
@@ -290,7 +290,7 @@
   id: HumanHairBusiness4
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business4
@@ -298,7 +298,7 @@
   id: HumanHairBuzzcut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: buzzcut
@@ -306,7 +306,7 @@
   id: HumanHairCia
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cia
@@ -314,7 +314,7 @@
   id: HumanHairClassicAfro
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicafro
@@ -322,7 +322,7 @@
   id: HumanHairClassicBigAfro
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicbigafro
@@ -337,7 +337,7 @@
   id: HumanHairClassicCia
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classiccia
@@ -352,7 +352,7 @@
   id: HumanHairClassicFloorlengthBedhead
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicfloorlength_bedhead
@@ -360,7 +360,7 @@
   id: HumanHairClassicModern
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicmodern
@@ -368,7 +368,7 @@
   id: HumanHairClassicMulder
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicmulder
@@ -376,7 +376,7 @@
   id: HumanHairClassicWisp
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicwisp
@@ -384,7 +384,7 @@
   id: HumanHairCoffeehouse
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: coffeehouse
@@ -392,7 +392,7 @@
   id: HumanHairCombover
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: combover
@@ -400,7 +400,7 @@
   id: HumanHairCornrows
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrows
@@ -408,7 +408,7 @@
   id: HumanHairCornrows2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrows2
@@ -416,7 +416,7 @@
   id: HumanHairCornrowbun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrowbun
@@ -424,7 +424,7 @@
   id: HumanHairCornrowbraid
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrowbraid
@@ -432,7 +432,7 @@
   id: HumanHairCornrowtail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrowtail
@@ -440,7 +440,7 @@
   id: HumanHairCrewcut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: crewcut
@@ -448,7 +448,7 @@
   id: HumanHairCurls
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: curls
@@ -456,7 +456,7 @@
   id: HumanHairC
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: c
@@ -464,7 +464,7 @@
   id: HumanHairDandypompadour
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: dandypompadour
@@ -472,7 +472,7 @@
   id: HumanHairDevilock
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: devilock
@@ -480,7 +480,7 @@
   id: HumanHairDoublebun
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: doublebun
@@ -495,7 +495,7 @@
   id: HumanHairDreads
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: dreads
@@ -503,7 +503,7 @@
   id: HumanHairDrillruru
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: drillruru
@@ -511,7 +511,7 @@
   id: HumanHairDrillhairextended
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: drillhairextended
@@ -519,7 +519,7 @@
   id: HumanHairEmo
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: emo
@@ -527,7 +527,7 @@
   id: HumanHairEmofringe
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: emofringe
@@ -535,7 +535,7 @@
   id: HumanHairNofade
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: nofade
@@ -543,7 +543,7 @@
   id: HumanHairHighfade
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: highfade
@@ -551,7 +551,7 @@
   id: HumanHairMedfade
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: medfade
@@ -559,7 +559,7 @@
   id: HumanHairLowfade
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: lowfade
@@ -567,7 +567,7 @@
   id: HumanHairBaldfade
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: baldfade
@@ -575,7 +575,7 @@
   id: HumanHairFeather
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: feather
@@ -583,7 +583,7 @@
   id: HumanHairFather
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: father
@@ -591,7 +591,7 @@
   id: HumanHairSargeant
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sargeant
@@ -599,7 +599,7 @@
   id: HumanHairFlair
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: flair
@@ -607,7 +607,7 @@
   id: HumanHairBigflattop
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bigflattop
@@ -615,7 +615,7 @@
   id: HumanHairFlow
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: f
@@ -623,7 +623,7 @@
   id: HumanHairGelled
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: gelled
@@ -631,7 +631,7 @@
   id: HumanHairGentle
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: gentle
@@ -639,7 +639,7 @@
   id: HumanHairHalfbang
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: halfbang
@@ -647,7 +647,7 @@
   id: HumanHairHalfbang2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: halfbang2
@@ -655,7 +655,7 @@
   id: HumanHairHalfshaved
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: halfshaved
@@ -663,7 +663,7 @@
   id: HumanHairHedgehog
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: hedgehog
@@ -671,7 +671,7 @@
   id: HumanHairHimecut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: himecut
@@ -679,7 +679,7 @@
   id: HumanHairHimecut2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: himecut2
@@ -687,7 +687,7 @@
   id: HumanHairShorthime
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthime
@@ -695,7 +695,7 @@
   id: HumanHairHimeup
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: himeup
@@ -703,7 +703,7 @@
   id: HumanHairHitop
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: hitop
@@ -711,7 +711,7 @@
   id: HumanHairJade
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: jade
@@ -719,7 +719,7 @@
   id: HumanHairJensen
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: jensen
@@ -727,7 +727,7 @@
   id: HumanHairJoestar
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: joestar
@@ -735,7 +735,7 @@
   id: HumanHairKeanu
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: keanu
@@ -743,7 +743,7 @@
   id: HumanHairKusanagi
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: kusanagi
@@ -751,7 +751,7 @@
   id: HumanHairLong
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long
@@ -759,7 +759,7 @@
   id: HumanHairLong2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long2
@@ -767,7 +767,7 @@
   id: HumanHairLong3
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long3
@@ -775,7 +775,7 @@
   id: HumanHairLongovereye
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longovereye
@@ -783,7 +783,7 @@
   id: HumanHairLbangs
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: lbangs
@@ -791,7 +791,7 @@
   id: HumanHairLongemo
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longemo
@@ -799,7 +799,7 @@
   id: HumanHairLongfringe
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longfringe
@@ -807,7 +807,7 @@
   id: HumanHairLongsidepart
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longsidepart
@@ -815,7 +815,7 @@
   id: HumanHairMegaeyebrows
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: megaeyebrows
@@ -823,7 +823,7 @@
   id: HumanHairMessy
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: messy
@@ -831,7 +831,7 @@
   id: HumanHairModern
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: modern
@@ -839,7 +839,7 @@
   id: HumanHairMohawk
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: d
@@ -847,7 +847,7 @@
   id: HumanHairNitori
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: nitori
@@ -855,7 +855,7 @@
   id: HumanHairReversemohawk
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: reversemohawk
@@ -863,7 +863,7 @@
   id: HumanHairUnshavenMohawk
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: unshaven_mohawk
@@ -871,7 +871,7 @@
   id: HumanHairMulder
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: mulder
@@ -879,7 +879,7 @@
   id: HumanHairOdango
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: odango
@@ -887,7 +887,7 @@
   id: HumanHairOmbre
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ombre
@@ -895,7 +895,7 @@
   id: HumanHairOneshoulder
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: oneshoulder
@@ -903,7 +903,7 @@
   id: HumanHairShortovereye
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shortovereye
@@ -911,7 +911,7 @@
   id: HumanHairOxton
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: oxton
@@ -919,7 +919,7 @@
   id: HumanHairParted
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: parted
@@ -927,7 +927,7 @@
   id: HumanHairPart
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: part
@@ -935,7 +935,7 @@
   id: HumanHairKagami
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: kagami
@@ -943,7 +943,7 @@
   id: HumanHairPigtails
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pigtails
@@ -951,7 +951,7 @@
   id: HumanHairPigtails2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pigtails2
@@ -959,7 +959,7 @@
   id: HumanHairPixie
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pixie
@@ -967,7 +967,7 @@
   id: HumanHairPompadour
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pompadour
@@ -975,7 +975,7 @@
   id: HumanHairBigpompadour
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bigpompadour
@@ -983,7 +983,7 @@
   id: HumanHairPonytail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail
@@ -991,7 +991,7 @@
   id: HumanHairPonytail2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail2
@@ -999,7 +999,7 @@
   id: HumanHairPonytail3
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail3
@@ -1007,7 +1007,7 @@
   id: HumanHairPonytail4
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail4
@@ -1015,7 +1015,7 @@
   id: HumanHairPonytail5
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail5
@@ -1023,7 +1023,7 @@
   id: HumanHairPonytail6
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail6
@@ -1031,7 +1031,7 @@
   id: HumanHairPonytail7
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail7
@@ -1039,7 +1039,7 @@
   id: HumanHairHighponytail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: highponytail
@@ -1047,7 +1047,7 @@
   id: HumanHairStail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: stail
@@ -1055,7 +1055,7 @@
   id: HumanHairLongstraightponytail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longstraightponytail
@@ -1063,7 +1063,7 @@
   id: HumanHairCountry
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: country
@@ -1071,7 +1071,7 @@
   id: HumanHairFringetail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: fringetail
@@ -1079,7 +1079,7 @@
   id: HumanHairSidetail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail
@@ -1087,7 +1087,7 @@
   id: HumanHairSidetail2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail2
@@ -1095,7 +1095,7 @@
   id: HumanHairSidetail3
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail3
@@ -1103,7 +1103,7 @@
   id: HumanHairSidetail4
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail4
@@ -1111,7 +1111,7 @@
   id: HumanHairSpikyponytail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spikyponytail
@@ -1119,7 +1119,7 @@
   id: HumanHairPoofy
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: poofy
@@ -1127,7 +1127,7 @@
   id: HumanHairQuiff
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: quiff
@@ -1135,7 +1135,7 @@
   id: HumanHairRonin
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ronin
@@ -1143,7 +1143,7 @@
   id: HumanHairShaved
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shaved
@@ -1151,7 +1151,7 @@
   id: HumanHairShavedpart
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shavedpart
@@ -1159,7 +1159,7 @@
   id: HumanHairShortbangs
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shortbangs
@@ -1167,7 +1167,7 @@
   id: HumanHairA
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: a
@@ -1175,7 +1175,7 @@
   id: HumanHairShorthair2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthair2
@@ -1183,7 +1183,7 @@
   id: HumanHairShorthair3
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthair3
@@ -1191,7 +1191,7 @@
   id: HumanHairD
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: d
@@ -1199,7 +1199,7 @@
   id: HumanHairE
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: e
@@ -1207,7 +1207,7 @@
   id: HumanHairF
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: f
@@ -1215,7 +1215,7 @@
   id: HumanHairShorthairg
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthairg
@@ -1223,7 +1223,7 @@
   id: HumanHair80s
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: 80s
@@ -1231,7 +1231,7 @@
   id: HumanHairRosa
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: rosa
@@ -1239,7 +1239,7 @@
   id: HumanHairB
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: b
@@ -1247,7 +1247,7 @@
   id: HumanHairSidecut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidecut
@@ -1255,7 +1255,7 @@
   id: HumanHairSkinhead
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: skinhead
@@ -1263,7 +1263,7 @@
   id: HumanHairProtagonist
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: protagonist
@@ -1271,7 +1271,7 @@
   id: HumanHairSpikey
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spikey
@@ -1279,7 +1279,7 @@
   id: HumanHairSpiky
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spiky
@@ -1287,7 +1287,7 @@
   id: HumanHairSpiky2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spiky2
@@ -1295,7 +1295,7 @@
   id: HumanHairSwept
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: swept
@@ -1303,7 +1303,7 @@
   id: HumanHairSwept2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: swept2
@@ -1318,7 +1318,7 @@
   id: HumanHairThinning
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: thinning
@@ -1326,7 +1326,7 @@
   id: HumanHairThinningfront
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: thinningfront
@@ -1334,7 +1334,7 @@
   id: HumanHairThinningrear
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: thinningrear
@@ -1342,7 +1342,7 @@
   id: HumanHairTopknot
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: topknot
@@ -1350,7 +1350,7 @@
   id: HumanHairTressshoulder
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: tressshoulder
@@ -1358,7 +1358,7 @@
   id: HumanHairTrimmed
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: trimmed
@@ -1366,7 +1366,7 @@
   id: HumanHairTrimflat
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: trimflat
@@ -1374,7 +1374,7 @@
   id: HumanHairTwintail
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: twintail
@@ -1389,7 +1389,7 @@
   id: HumanHairUndercut
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: undercut
@@ -1397,7 +1397,7 @@
   id: HumanHairUndercutleft
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: undercutleft
@@ -1405,7 +1405,7 @@
   id: HumanHairUndercutright
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: undercutright
@@ -1413,7 +1413,7 @@
   id: HumanHairUnkept
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: unkept
@@ -1421,7 +1421,7 @@
   id: HumanHairUpdo
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: updo
@@ -1429,7 +1429,7 @@
   id: HumanHairVlong
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: vlong
@@ -1437,7 +1437,7 @@
   id: HumanHairLongest
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longest
@@ -1445,7 +1445,7 @@
   id: HumanHairLongest2
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longest2
@@ -1453,7 +1453,7 @@
   id: HumanHairVeryshortovereyealternate
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: veryshortovereyealternate
@@ -1461,7 +1461,7 @@
   id: HumanHairVlongfringe
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: vlongfringe
@@ -1469,7 +1469,7 @@
   id: HumanHairVolaju
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: volaju
@@ -1477,7 +1477,7 @@
   id: HumanHairWisp
   bodyPart: Hair
   markingCategory: Hair
-  speciesRestriction: [Human, SlimePerson, Reptilian]
+  #speciesRestriction: [Human, SlimePerson, Reptilian]
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: wisp


### PR DESCRIPTION
## About the PR

CD, in the process of 'giving Avali their hair back' restricted humanoid hair to far too few races. This makes all humanoid hair available to all humanoid species. The list is...quite long (but hey, Humans, Slimes, and Reptilians already had that!), but I think it is worth it to have that choice. These are commented out for now in case we want to revisit down the line.

## Why / Balance

Skunks require bedhead.
