### PR TITLE
Show subfloor above everything when in ShowAll mode

### DIFF
--- a/Content.Client/SubFloor/SubFloorHideSystem.cs
+++ b/Content.Client/SubFloor/SubFloorHideSystem.cs
@@ -1,13 +1,16 @@
 using Content.Shared.DrawDepth;
+using Content.Shared.Mobs;
 using Content.Shared.SubFloor;
 using Robust.Client.GameObjects;
+using Robust.Client.UserInterface;
+using Content.Client.Ghost;
 
 namespace Content.Client.SubFloor;
 
 public sealed class SubFloorHideSystem : SharedSubFloorHideSystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-
+    [UISystemDependency] private readonly Ghost.GhostSystem? _ghost = default;
     private bool _showAll;
 
     [ViewVariables(VVAccess.ReadWrite)]
@@ -74,6 +77,12 @@ public sealed class SubFloorHideSystem : SharedSubFloorHideSystem
         {
             args.Sprite.DrawDepth = component.OriginalDrawDepth.Value;
             component.OriginalDrawDepth = null;
+        }
+
+        // If we are showing all (as we will be while mapping), draw the sprites above everything.
+        if (ShowAll)
+        {
+            args.Sprite.DrawDepth = (int) Shared.DrawDepth.DrawDepth.Overdoors + 1;
         }
     }
 


### PR DESCRIPTION
## About the PR

Handy to see the subfloor above everything when it's visible in mapping mode. Otherwise, have to keep right-clicking or delete all objects. So it's potentially messy! Who cares?

## Why / Balance

Mapping the subfloor sucks when walls are in place, and sometimes you need those to test FOV

## How to test

Start mapping, add tiles, add walls, add power cables, toggle subfloors
