### PR TITLE
Fix CPR logic flow bugs

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -248,6 +248,7 @@ public sealed class RespiratorSystem : EntitySystem
         if (!args.Cancelled && TryComp<RespiratorComponent>(args.Target, out var respirator))
         {
             respirator.BreatheInCritCounter += (int)_random.NextFloat(2, 4);
+            args.Repeat = true;
 
             if (!HasComp<MedicalTrainingComponent>(args.User) && TryComp<PhysicsComponent>(args.Target, out var patientPhysics) && TryComp<PhysicsComponent>(args.User, out var perfPhysics))
             {
@@ -265,10 +266,6 @@ public sealed class RespiratorSystem : EntitySystem
 
                     component.CPRPlayingStream = _audio.Stop(component.CPRPlayingStream);
                     args.Repeat = false;
-                }
-                else
-                {
-                    args.Repeat = true;
                 }
             }
         }
@@ -310,7 +307,7 @@ public sealed class RespiratorSystem : EntitySystem
             return true;
         }
 
-        if (args.Handled || !_blocker.CanInteract(args.User, args.Target))
+        if (args.Handled || !_blocker.CanInteract(args.User, args.Target) || !Check())
             return;
 
         bool isTrained = TryComp<MedicalTrainingComponent>(args.User, out _);


### PR DESCRIPTION
## About the PR
This commit contains two key bugfixes:
1. Applying CPR with the Medical Training component now repeats as expected, instead of entering a bugged state.
1. Attempting to apply CPR now aborts if the checks fail instead of entering a bugged state.