### PR TITLE
Fix race condition in distress signal rule

### DIFF
--- a/Content.Server/_Lagrange/StationEvents/Events/DistressSignalRule.cs
+++ b/Content.Server/_Lagrange/StationEvents/Events/DistressSignalRule.cs
@@ -101,11 +101,19 @@ public sealed class DistressSignalRule : StationEventSystem<DistressSignalRuleCo
 
         if (component.Objectives.Count == 0)
         {
-            Log.Error($"Distress signal '{component.MapId}' lacks objectives and was thus aborted.");
-            if (component.GridUid is not null)
-                Del(component.GridUid);
-            GameTicker.EndGameRule(uid);
-            return;
+            component.TimerRunning = true;
+            Timer.Spawn(TimeSpan.FromSeconds(1), () =>
+            {
+                component.TimerRunning = false;
+                if (component.Objectives.Count == 0)
+                {
+                    Log.Error($"Distress signal '{component.MapId}' lacks objectives and was thus aborted.");
+                    if (component.GridUid is not null)
+                        Del(component.GridUid);
+                    GameTicker.EndGameRule(uid);
+                    return;
+                }
+            });
         }
 
         // Determine whether a (partially) successful attempt to address the distress signal has been made.


### PR DESCRIPTION
## About the PR
This commit simply adds a delay before beginning objective checks, which was previously causing distress signals to abort before registering their objectives.