### PR TITLE
Add non-subfloor versions of planet/asteroid terrain tiles.

### DIFF
--- a/Resources/Locale/en-US/_Lagrange/tiles.ftl
+++ b/Resources/Locale/en-US/_Lagrange/tiles.ftl
@@ -1,0 +1,11 @@
+tiles-non-subfloor-asphalt = non-subfloor asphalt
+tiles-non-subfloor-planet-grass-floor = non-subfloor grass floor
+tiles-non-subfloor-jungle-grass-floor = non-subfloor jungle grass floor
+tiles-non-subfloor-dark-grass-floor = non-subfloor dark grass floor
+tiles-non-subfloor-light-grass-floor = non-subfloor light grass floor
+tiles-non-subfloor-dirt-floor = non-subfloor dirt floor
+tiles-non-subfloor-asteroid-sand = non-subfloor asteroid sand
+tiles-non-subfloor-asteroid-sand-dug = non-subfloor dug asteroid sand
+tiles-non-subfloor-asteroid-tile = non-subfloor asteroid tile
+tiles-non-subfloor-asteroid-plating = non-subfloor asteroid plating
+tiles-non-subfloor-asteroid-ironsand = non-subfloor asteroid ironsand

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1503,6 +1503,125 @@
   heatCapacity: 10000
   weather: true
 
+# Non-subfloor Terrain
+
+- type: tile
+  id: FloorAsphaltNonsubfloor
+  name: tiles-non-subfloor-asphalt
+  sprite: /Textures/Tiles/Planet/Concrete/asphalt.png
+  variants: 10
+  placementVariants:
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  baseTurf: Plating
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepTile
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorGrassNonsubfloor
+  name: tiles-non-subfloor-planet-grass-floor
+  sprite: /Textures/Tiles/grass.png
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  #canShovel: true # Delta V
+  footstepSounds:
+    collection: FootstepGrass
+  itemDrop: FloorTileItemGrass
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorGrassJungleNonsubfloor
+  name: tiles-non-subfloor-jungle-grass-floor
+  sprite: /Textures/Tiles/grassjungle.png
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  #canShovel: true # Delta V
+  footstepSounds:
+    collection: FootstepGrass
+  itemDrop: FloorTileItemGrassJungle
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorGrassDarkNonsubfloor
+  name: tiles-non-subfloor-dark-grass-floor
+  sprite: /Textures/Tiles/grassdark.png
+  variants: 4
+  placementVariants:
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  #canShovel: true # Delta V
+  footstepSounds:
+    collection: FootstepGrass
+  itemDrop: FloorTileItemGrassDark # Delta V
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorGrassLightNonsubfloor
+  name: tiles-non-subfloor-light-grass-floor
+  sprite: /Textures/Tiles/grasslight.png
+  variants: 4
+  placementVariants:
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  #canShovel: true # Delta V
+  footstepSounds:
+    collection: FootstepGrass
+  itemDrop: FloorTileItemGrassLight
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorDirtNonsubfloor
+  name: tiles-non-subfloor-dirt-floor
+  sprite: /Textures/Tiles/dirt.png
+  variants: 4
+  placementVariants:
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  #canShovel: true # Delta V
+  footstepSounds:
+    collection: FootstepAsteroid
+  itemDrop: FloorTileItemDirt # Delta V
+  heatCapacity: 10000
+  weather: true
+
 # Asteroid
 
 - type: tile
@@ -1625,6 +1744,146 @@
   sprite: /Textures/Tiles/Asteroid/ironsand0.png
   baseTurf: Space
   isSubfloor: true
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
+# Non-subfloor Asteroid
+
+- type: tile
+  id: FloorAsteroidSand
+  name: tiles-non-subfloor-asteroid-sand
+  sprite: /Textures/Tiles/Asteroid/asteroid.png
+  variants: 13
+  placementVariants:
+  - 0.8
+  - 0.0166 #Should be roughly 20%.... I think??? I don't know dude, I'm just a YAML monkey.
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0116
+  - 0.0116
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorAsteroidSandDugNonSubfloor
+  name: tiles-non-subfloor-asteroid-sand
+  sprite: /Textures/Tiles/Asteroid/asteroid_dug.png
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorAsteroidSandRedNonSubfloor
+  name: tiles-non-subfloor-asteroid-sand
+  sprite: /Textures/Tiles/Asteroid/asteroid_red.png
+  variants: 13
+  placementVariants:
+  - 0.8
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0166
+  - 0.0116
+  - 0.0116
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorAsteroidTileNonSubfloor
+  name: tiles-non-subfloor-asteroid-tile
+  sprite: /Textures/Tiles/Asteroid/asteroid_tile.png
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorAsteroidIronsandNonSubfloor
+  name: tiles-non-subfloor-asteroid-ironsand
+  sprite: /Textures/Tiles/Asteroid/ironsand.png
+  variants: 15
+  placementVariants:
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  - 1.0
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorAsteroidSandUnvariantizedNonSubfloor
+  name: tiles-non-subfloor-asteroid-sand
+  sprite: /Textures/Tiles/Asteroid/asteroid0.png
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
+  footstepSounds:
+    collection: FootstepAsteroid
+  heatCapacity: 10000
+  weather: true
+
+- type: tile
+  id: FloorAsteroidIronsandUnvariantizedNonSubfloor
+  name: tiles-non-subfloor-asteroid-ironsand
+  sprite: /Textures/Tiles/Asteroid/ironsand0.png
+  baseTurf: Plating
+  canCrowbar: true
+  isSubfloor: false # Lagrange
+  deconstructTools: [ Prying ]
   footstepSounds:
     collection: FootstepAsteroid
   heatCapacity: 10000


### PR DESCRIPTION
## About the PR

We are using these for natural areas in the station, but as they are marked as subfloor, pipes/wires show above them. These non-subfloor versions may be found in the tiles dialog (F6) by searching for 'non-subfloor'. They are currently able to be removed with prying, with the thought that they are essentially trays on which the material sits. When we are further along with spriting, there may be a separate branch for creating sprites of these for when they are pried up (e.g: when you pry up sand tiles, they show up as 2x2 steel tiles because there aren't sprites for those entities).